### PR TITLE
Use CNN face detector as fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Supported on Python 3 and OpenCV 3+. Tested on macOS High Sierra and Mojave.
 ```
 git clone https://github.com/andrewdcampbell/face-movie
 ```
-2. Download the trained face detector model from [here](http://dlib.net/files/shape_predictor_68_face_landmarks.dat.bz2). Unzip it and place it in the root directory of the repo.
+2. Download the trained face shape predictor model from [here](http://dlib.net/files/shape_predictor_68_face_landmarks.dat.bz2). Unzip it and place it in the root directory of the repo. Do the same with the [detector model](http://dlib.net/files/mmod_human_face_detector.dat.bz2).
 
 ## Creating a face movie - reccomended workflow
 

--- a/face-movie/align.py
+++ b/face-movie/align.py
@@ -6,6 +6,7 @@ import numpy as np
 import argparse
 import os
 
+DETECTOR_PATH = "./mmod_human_face_detector.dat"
 PREDICTOR_PATH = "./shape_predictor_68_face_landmarks.dat"
 
 FACE_POINTS = list(range(17, 68))
@@ -22,7 +23,8 @@ ALIGN_POINTS = (LEFT_BROW_POINTS + RIGHT_EYE_POINTS + LEFT_EYE_POINTS +
                     RIGHT_BROW_POINTS + NOSE_POINTS + MOUTH_POINTS)
 
 
-DETECTOR = dlib.get_frontal_face_detector()
+DETECTOR1 = dlib.get_frontal_face_detector()
+DETECTOR2 = dlib.cnn_face_detection_model_v1(DETECTOR_PATH)
 PREDICTOR = dlib.shape_predictor(PREDICTOR_PATH)
 
 cache = dict()
@@ -48,9 +50,14 @@ def prompt_user_to_choose_face(im, rects):
     return rects[target_index]
 
 def get_landmarks(im):
-    rects = DETECTOR(im, 1)
-    if len(rects) == 0 and len(DETECTOR(im, 0)) > 0:
-        rects = DETECTOR(im, 0)
+    rects = DETECTOR1(im, 1)
+    if len(rects) == 0:
+        rects = DETECTOR1(im, 0)
+        if len(rects) == 0:
+            rects = DETECTOR2(im, 1)
+            if len(rects) == 0:
+                rects = DETECTOR2(im, 0)
+            rects = [r.rect for r in rects]
     assert len(rects) > 0, "No faces found!"
     target_rect = rects[0] 
     if len(rects) > 1:

--- a/face-movie/main.py
+++ b/face-movie/main.py
@@ -15,8 +15,10 @@ import time
 # FACIAL LANDMARK DETECTION CODE
 ########################################
 
+DETECTOR_PATH = "./mmod_human_face_detector.dat"
 PREDICTOR_PATH = "./shape_predictor_68_face_landmarks.dat"
-DETECTOR = dlib.get_frontal_face_detector()
+DETECTOR1 = dlib.get_frontal_face_detector()
+DETECTOR2 = dlib.cnn_face_detection_model_v1(DETECTOR_PATH)
 PREDICTOR = dlib.shape_predictor(PREDICTOR_PATH)
 
 def get_boundary_points(shape):
@@ -28,14 +30,19 @@ def get_boundary_points(shape):
     return np.array(boundary_pts)
 
 def get_landmarks(im):
-    rects = DETECTOR(im, 1)
-    if len(rects) == 0 and len(DETECTOR(im, 0)) > 0:
-        rects = DETECTOR(im, 0)
+    rects = DETECTOR1(im, 1)
+    if len(rects) == 0:
+        rects = DETECTOR1(im, 0)
+        if len(rects) == 0:
+            rects = DETECTOR2(im, 1)
+            if len(rects) == 0:
+                rects = DETECTOR2(im, 0)
+            rects = [r.rect for r in rects]
 
     if len(rects) == 0:
         return None
 
-    target_rect = rects[0] 
+    target_rect = rects[0]
     if len(rects) > 1:
         target_rect = prompt_user_to_choose_face(im, rects)
 


### PR DESCRIPTION
Since dlib's frontal_face_detector didn't work well for my photos (admittedly not only clear frontal views), I tried to use the CNN detector, that is also present in dlib. It is much slower, though, so I used the given compromise: try the traditional face detector first and fall back to the CNN detector.

For the small subset of images of mine, this created a huge stability advantage (didn't work before, worked afterwards) for as low a time cost as possible. I didn't experience problems of incompatibilities between the detected points.